### PR TITLE
Second Round of Optimization of Communication Endpoints

### DIFF
--- a/src/daisy/communication/tests/simple_server.py
+++ b/src/daisy/communication/tests/simple_server.py
@@ -24,6 +24,7 @@ def simple_server():
         addr=("127.0.0.1", 13000),
         c_timeout=None,
         multithreading=True,
+        keep_alive=False,
     ) as server:
         i = 0
         while True:


### PR DESCRIPTION
Optimization:
- Added a keep-alive flag to sort out endpoints whose remote counterpart has closed() the connection
    - sync endpoints now throw runtime errors when such events occur during send/recv()
    - async endpoints' sender/receiver threads clean up after themselves when such event occurs and the endpoint closes by itself
    - shutdowns can still be excuted manually or left to garbage collection 
    - this optimizes single-use endpoints where endpoints are rapidly opened and closed
-  Closed async endpoints now support receive() if their internal buffers are not empty before throwing errors (mirroring the behavior of system sockets)
- added exponential backoff to endpoint sockets' sleep() between re-connection attempts, the longer they have stayed dead
    - there is a bottleneck due to class variables and their acces by all endpoint threads, especially those who share a common listen address
    - long sleeps between connection attempts caue delays for new connections, while long timeouts on the accept() for acceptor sockets create severe bottlenecks for the locks securing access for that part of the code
    -  now accept() is still nonblocking, but new acceptors are excempt from the penalty, resulting in an average time to establish a connection below 1sec instead of of scaling with the number of sockets currently waiting for a connection
    - this change may cause trouble down the line if critical connections need to be re-established but they wait until they attempt to do so; the backoff may need to be parametrized in the future
- removed a  timeout from the connection handler of the endpoint server, causing delays for new connections when the pending connection queue of the server is never utilized

Bugfixes:
- EndpointServer no longer waits for nonexisting cleanup threads (timeout=None)