### PR TITLE
Fixed circular import error in DataSources

### DIFF
--- a/src/daisy/data_sources/data_relay.py
+++ b/src/daisy/data_sources/data_relay.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from daisy.communication import StreamEndpoint
-from daisy.data_sources import DataSource
+from .data_source import DataSource
 
 
 class DataSourceRelay:

--- a/src/daisy/data_sources/data_source.py
+++ b/src/daisy/data_sources/data_source.py
@@ -18,7 +18,8 @@ from typing import Iterator
 
 import numpy as np
 
-from daisy.data_sources import SourceHandler, DataProcessor
+from .data_handler import SourceHandler
+from .data_processor import DataProcessor
 
 
 class DataSource:

--- a/src/daisy/data_sources/network_traffic/pyshark_processor.py
+++ b/src/daisy/data_sources/network_traffic/pyshark_processor.py
@@ -30,7 +30,7 @@ from pyshark.packet.layers.json_layer import JsonLayer
 from pyshark.packet.layers.xml_layer import XmlLayer
 from pyshark.packet.packet import Packet
 
-from daisy.data_sources import SimpleDataProcessor
+from ..data_processor import SimpleDataProcessor
 
 # Exemplary network feature filter, supporting cohda-box (V2x) messages, besides
 # TCP/IP and ETH.


### PR DESCRIPTION
Changed imports to be relative instead of absolute, which threw
circular import exceptions upon importing them.