### PR TITLE
Bugfix: Message Stream no longer has not found import for lz4

### DIFF
--- a/src/daisy/communication/message_stream.py
+++ b/src/daisy/communication/message_stream.py
@@ -7,7 +7,7 @@
 endpoints over BSD sockets. Supports SSL (soon) and LZ4 compression.
 
 Author: Fabian Hofmann
-Modified: 29.04.24
+Modified: 16.10.24
 """
 # TODO Future Work: SSL https://docs.python.org/3/library/ssl.html
 # TODO Future Work: Defining granularity of logging in inits


### PR DESCRIPTION
Only an issue for some distributions and interpreter configurations, as the dependencies are not properly provided in the __innit__ file for lz4 (no __all__ var), but instead imported pre-compiled functions.