### PR TITLE
Fix: Deprecated decorator 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ dependencies = [
     "plotly~=5.14.1",
     "django~=5.0.1",
     "djangorestframework~=3.14.0",
-    "pyparsing~=3.2.0"
+    "pyparsing~=3.2.0",
+    "typing-extensions~=4.12.2"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/src/daisy/data_sources/data_processor.py
+++ b/src/daisy/data_sources/data_processor.py
@@ -17,7 +17,7 @@ import json
 import logging
 from collections.abc import MutableMapping
 from typing import Callable, Self
-from warnings import deprecated
+from typing_extensions import deprecated
 
 import numpy as np
 

--- a/src/daisy/data_sources/network_traffic/pyshark_processor.py
+++ b/src/daisy/data_sources/network_traffic/pyshark_processor.py
@@ -22,7 +22,7 @@ import sys
 from collections import defaultdict
 from ipaddress import AddressValueError
 from typing import Callable, Self
-from warnings import deprecated
+from typing_extensions import deprecated
 
 import numpy as np
 from pyshark.packet.fields import LayerField, LayerFieldsContainer


### PR DESCRIPTION
Added the library typing-extensions and replaced the warnings package with it for the deprecated import. 