### PR TITLE
fix: Fix django start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 ARG BUILD_VERSION=cpu
 
-
 # Setup of Depedencies:
 FROM python:3.12-slim AS setup
+# System-Updates & Installation von net-tools für netstat
 WORKDIR /app
 # setup of venv
 RUN python3 -m venv ./venv
@@ -27,7 +27,7 @@ WORKDIR /app
 EXPOSE 8000-8003
 # installtion of additional (non-python/venv) dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive  \
-    apt-get install --no-install-recommends -y tshark \
+    apt-get install --no-install-recommends -y tshark net-tools\
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 # Import of CPU Dependencies:

--- a/src/daisy/federated_ids_components/dashboard/dashboard/settings.py
+++ b/src/daisy/federated_ids_components/dashboard/dashboard/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = "django-insecure-5-twkmo)3^^(*^sgc7zb$0jv6gad$h+2eb&f363cw!k$wl*3r8
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 # Application definition
 

--- a/src/daisy/scripts/generic_fids_components/dashboard.py
+++ b/src/daisy/scripts/generic_fids_components/dashboard.py
@@ -30,7 +30,13 @@ def create_dashboard():
 
     os.system(f"python {dashboard_path} makemigrations")
     os.system(f"python {dashboard_path} migrate")
-    os.system(f"python {dashboard_path} runserver")
+    DASHBOARD_IP = os.getenv(
+        "DASHBOARD_PORT", "0.0.0.0"
+    )  # Standardport 8000, falls keine Variable gesetzt ist
+    DASHBOARD_PORT = os.getenv(
+        "DASHBOARD_PORT", "8000"
+    )  # Standardport 8000, falls keine Variable gesetzt ist
+    os.system(f"python {dashboard_path} runserver {DASHBOARD_IP}:{DASHBOARD_PORT}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change django server of dashboard to start under "0.0.0.0:8000". 
Now, the dashboard is reachable. 

Fixes in ...\daisy\src\daisy\federated_ids_components\dashboard\dashboard\settings.py =>
ALLOWED_HOSTS = ["*"] 

and in  ...\daisy\src\daisy\scripts\generic_fids_components\dashboard.py =>
DASHBOARD_IP = os.getenv("DASHBOARD_PORT", "0.0.0.0")  # Standardport 8000, falls keine Variable gesetzt ist
DASHBOARD_PORT = os.getenv("DASHBOARD_PORT", "8000")  # Standardport 8000, falls keine Variable gesetzt ist
os.system(f"python {dashboard_path} runserver {DASHBOARD_IP}:{DASHBOARD_PORT}")