### PR TITLE
fix: conf matrix eval now returns ONLY tensors

### DIFF
--- a/src/daisy/evaluation/anomaly_detection_online_evaluation.py
+++ b/src/daisy/evaluation/anomaly_detection_online_evaluation.py
@@ -183,7 +183,7 @@ class ConfMatrSlidingWindowEvaluation(SlidingWindowEvaluation):
 
         :return: Dictionary of all derived scalar (tensor) confusion matrix metrics.
         """
-        accuracy = (self._tp + self._tn) / len(self.true_labels)
+        accuracy = tf.convert_to_tensor((self._tp + self._tn) / len(self.true_labels))
         recall = tf.math.divide_no_nan(self._tp, (self._tp + self._fn))
         tnr = tf.math.divide_no_nan(self._tn, (self._tn + self._fp))
         precision = tf.math.divide_no_nan(self._tp, (self._tp + self._fp))


### PR DESCRIPTION
- It is unclear why this issue is now happening, but the accuracy has always been a float value, not a tensor
- ever since upgrading tensorflow, one can no longer convert floats into numpy values using tensorflow, causing an Error
- to fix it, the accuracy is simply converted to a tensor as well, which is in compliance to the TF Metrics documentation